### PR TITLE
Implement explicit carbons options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 No server, no images, no templates, just a SMILES 😊
 
-Current Version: **2.1.5**
+Forked to implement and test new features for mxp.
+
+Current Version: **2.1.8**
 
 <table style="width: 100%; table-layout: fixed">
     <tbody>
@@ -197,6 +199,7 @@ The following options are available:
 | Padding                                                         | padding                     | number                              | 20.0          |
 | Use experimental features                                       | experimental                | boolean                             | false         |
 | Show Terminal Carbons (CH3)                                     | terminalCarbons             | boolean                             | false         |
+| Show explicit carbons                                           | explicitCarbons             | string ['none', 'all', 'isotopes']  | 'none'        |
 | Show explicit hydrogens                                         | explicitHydrogens           | boolean                             | false         |
 | Overlap sensitivity                                             | overlapSensitivity          | number                              | 0.42          |
 | # of overlap resolution iterations                              | overlapResolutionIterations | number                              | 1             |
@@ -219,6 +222,7 @@ The default options are defined as follows:
     isomeric: true,
     debug: false,
     terminalCarbons: false,
+    explicitCarbons: 'none',
     explicitHydrogens: false,
     overlapSensitivity: 0.42,
     overlapResolutionIterations: 1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smiles-drawer",
-  "version": "2.1.2",
+  "version": "2.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "smiles-drawer",
-      "version": "2.1.2",
+      "version": "2.1.8",
       "license": "MIT",
       "dependencies": {
         "chroma-js": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smiles-drawer",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "A SMILES drawer and parser. Generate molecular structure depictions in pure JavaScript.",
   "main": "./app.js",
   "repository": "https://github.com/reymond-group/smilesDrawer.git",

--- a/src/Drawer.js
+++ b/src/Drawer.js
@@ -44,7 +44,7 @@ class Drawer {
     svg.setAttributeNS(null, 'viewBox', '0 0 ' + this.svgDrawer.opts.width + ' ' + this.svgDrawer.opts.height);
     svg.setAttributeNS(null, 'width', this.svgDrawer.opts.width + '');
     svg.setAttributeNS(null, 'height', this.svgDrawer.opts.height + '');
-    this.svgDrawer.draw(data, svg, themeName, infoOnly, highlight_atoms);
+    this.svgDrawer.draw(data, svg, themeName, null, infoOnly, highlight_atoms);
     this.svgDrawer.svgWrapper.toCanvas(canvas, this.svgDrawer.opts.width, this.svgDrawer.opts.height);
   }
 

--- a/src/DrawerBase.js
+++ b/src/DrawerBase.js
@@ -53,6 +53,7 @@ class DrawerBase {
       isomeric: true,
       debug: false,
       terminalCarbons: false,
+      explicitCarbons: 'none',
       explicitHydrogens: true,
       overlapSensitivity: 0.42,
       overlapResolutionIterations: 1,

--- a/src/SvgDrawer.js
+++ b/src/SvgDrawer.js
@@ -362,6 +362,15 @@ class SvgDrawer {
         isotope = atom.bracket.isotope;
       }
 
+      if (
+        isCarbon &&
+        (opts.explicitCarbons === 'all' ||
+          (opts.explicitCarbons === 'isotopes' && isotope != 0))
+      ) {
+        atom.drawExplicit = true;
+        if (!vertex.isTerminal()) hydrogens = 0;
+      }
+
       if (opts.atomVisualization === 'allballs') {
         svgWrapper.drawBall(vertex.position.x, vertex.position.y, element);
       } else if ((atom.isDrawn && (!isCarbon || atom.drawExplicit || isTerminal || atom.hasAttachedPseudoElements)) || graph.vertices.length === 1) {


### PR DESCRIPTION
This pull request implements options to display carbons explicitly. "none" is the typical behavior pre-update, "all" will explicitly label all carbons, and "isotopes" will label 13C's. Hydrogens attached to the carbons are still hidden (except on terminal carbons) to reduce clutter and overlap.

This also fixes a bug that broke the canvas drawer.